### PR TITLE
fix deprecation error on ErrorException (since PHP 8.1)

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -449,7 +449,7 @@ class Client
     public static function onError($level, $message, $file, $line)
     {
         $message = trim($message);
-        $code = null;
+        $code = 0;
 
         throw new ErrorException($message, $code, $level, $file, $line);
     }


### PR DESCRIPTION
Passing null to parameter #2 ($code) of type int is deprecated in vendor/datto/json-rpc-http/src/Client.php on line 461