### PR TITLE
fix deprecation error on PHP 8.3 on stream_context_set_options()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -220,7 +220,14 @@ class Client
 
         try {
             $options = $this->getStreamOptions();
-            stream_context_set_option($this->context, $options);
+            if (PHP_VERSION_ID >= 80300)
+            {
+                stream_context_set_options($this->context, $options);
+            }
+            else
+            {
+                stream_context_set_option($this->context, $options);
+            }
             $message = file_get_contents($this->uri, false, $this->context);
 
             $this->throwHttpExceptionOnHttpError($http_response_header);


### PR DESCRIPTION
"Calling stream_context_set_option() with 2 arguments is deprecated, use stream_context_set_options() instead" at vendor/datto/json-rpc-http/src/Client.php:223