### PR TITLE
fix deprecation error on PHP 8.4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -114,7 +114,7 @@ class Client
      *
      * @see http://php.net/manual/en/context.http.php HTTP options
      */
-    public function __construct($uri, array $headers = null, array $options = null)
+    public function __construct($uri, $headers = null, $options = null)
     {
         $this->requiredHttpHeaders = array(
             'Accept' => self::$CONTENT_TYPE,


### PR DESCRIPTION
Implicitly marking parameter $headers as nullable is deprecated, the explicit nullable type must be used instead on line 117 in file vendor/datto/json-rpc-http/src/Client.php